### PR TITLE
bugfix: nuget deployment

### DIFF
--- a/.github/workflows/dotnet-deploy.yaml
+++ b/.github/workflows/dotnet-deploy.yaml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Build Novu
         working-directory: ./src/Novu
-        run: dotnet build
+        run: dotnet build --configuration Release
 
       - name: Get version
         id: version

--- a/.github/workflows/dotnet-test.yaml
+++ b/.github/workflows/dotnet-test.yaml
@@ -4,6 +4,11 @@ on:
   pull_request:
     branches: [main]
 
+env:
+  PROJECT_PATH: "./src/Novu/Novu.csproj"
+  PACKAGE_OUTPUT_DIRECTORY: ${{ github.workspace }}\output
+  NUGET_SOURCE_URL: "https://api/nuget/org/v3/index.json"
+
 jobs:
   build_and_test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixed the bug that kept the action from deploying to Nuget.

Cause:

When the `dotnet-deploy.yaml` file was ran, it would build Novu but since the `--configuration Release` flag wasn't set, it deployed it as a `Debug` build, which is a different folder structure. Therefore, when `dotnet pack` looked for the `.dll` file, it couldn't be found.