### PR TITLE
bugfix: removed nuget debug symbols

### DIFF
--- a/.github/workflows/dotnet-deploy.yaml
+++ b/.github/workflows/dotnet-deploy.yaml
@@ -60,7 +60,7 @@ jobs:
         uses: battila7/get-version-action@v2
 
       - name: Create Nuget package
-        run: dotnet pack ${{ env.PROJECT_PATH }} --no-restore --no-build --configuration Release --include-symbols -p:PackageVersion=${{ steps.version.outputs.version-without-v }} --output ${{ env.PACKAGE_OUTPUT_DIRECTORY }}
+        run: dotnet pack ${{ env.PROJECT_PATH }} --no-restore --no-build --configuration Release -p:PackageVersion=${{ steps.version.outputs.version-without-v }} --output ${{ env.PACKAGE_OUTPUT_DIRECTORY }}
 
       - name: Push Nuget package
         run: dotnet nuget push ${{ env.PACKAGE_OUTPUT_DIRECTORY}}/*.nupkg -k ${{ secrets.NUGET_AUTH_TOKEN }} -s ${{ env.NUGET_SOURCE_URL}}


### PR DESCRIPTION
debug symbols improve the debugging experience, however they're not needed in a separate nuget package.